### PR TITLE
Better JSF 2.3 support

### DIFF
--- a/components/nodejs/src/butterfaces-ts/butterfaces-ajax.ts
+++ b/components/nodejs/src/butterfaces-ts/butterfaces-ajax.ts
@@ -1,4 +1,4 @@
-///<reference path="../../node_modules/@types/jee-jsf/index.d.ts"/>
+///<reference path="../type-definition/jsf-ajax/index.d.ts"/>
 ///<reference path="butterfaces-overlay.ts"/>
 
 namespace ButterFaces {
@@ -8,6 +8,7 @@ namespace ButterFaces {
                 "javax.faces.behavior.event": event,
                 render: renderIds.join(", "),
                 params: params,
+                "butterfaces.params": params,
                 onevent: (function (data) {
                     // console.log(data);
                     if (disableRenderIds) {

--- a/components/nodejs/src/type-definition/jsf-ajax/index.d.ts
+++ b/components/nodejs/src/type-definition/jsf-ajax/index.d.ts
@@ -1,0 +1,16 @@
+///<reference path="../../../node_modules/@types/jee-jsf/index.d.ts"/>
+// Copy of jee-jsf/index.d.ts because params does not work correctly in thorntail jsf 2.3 implementation
+// Extend jsf.ajax.RequestOptions by attribute butterfaces.params
+
+declare namespace jsf {
+    namespace ajax {
+        interface RequestOptions {
+
+            /**
+             * Additional to params, because params does not work...
+             */
+            'butterfaces.params'?: any;
+
+        }
+    }
+}

--- a/components/src/main/java/org/butterfaces/component/behavior/JsfAjaxRequest.java
+++ b/components/src/main/java/org/butterfaces/component/behavior/JsfAjaxRequest.java
@@ -236,6 +236,12 @@ public class JsfAjaxRequest {
                 isAtLeastOneOptionSet = true;
             }
 
+            if (StringUtils.isNotEmpty(params)) {
+                writeSeparatorIfNecessary(sb, isAtLeastOneOptionSet);
+                sb.append("'butterfaces.params': ").append(params);
+                isAtLeastOneOptionSet = true;
+            }
+
             if (StringUtils.isNotEmpty(behaviorEvent)) {
                 writeSeparatorIfNecessary(sb, isAtLeastOneOptionSet);
                 sb.append("'javax.faces.behavior.event': '").append(behaviorEvent).append("'");

--- a/components/src/main/java/org/butterfaces/component/renderkit/html_basic/table/TableToolbarRenderer.java
+++ b/components/src/main/java/org/butterfaces/component/renderkit/html_basic/table/TableToolbarRenderer.java
@@ -15,6 +15,7 @@ import org.butterfaces.component.renderkit.html_basic.table.cache.TableColumnCac
 import org.butterfaces.model.table.TableColumnOrdering;
 import org.butterfaces.model.table.TableColumnVisibility;
 import org.butterfaces.model.table.json.JsonToModelConverter;
+import org.butterfaces.resolver.AjaxRequestParameter;
 import org.butterfaces.resolver.ClientBehaviorResolver;
 import org.butterfaces.resolver.UIComponentResolver;
 import org.butterfaces.resolver.WebXmlParameters;
@@ -123,19 +124,20 @@ public class TableToolbarRenderer extends HtmlBasicRenderer {
         final ExternalContext external = context.getExternalContext();
         final Map<String, String> params = external.getRequestParameterMap();
         final String behaviorEvent = params.get("javax.faces.behavior.event");
-        final HtmlTable table = getTableComponent(tableToolbar);
-        final String tableUniqueIdentifier = table.getModelUniqueIdentifier();
 
         if (behaviorEvent != null) {
+            final HtmlTable table = getTableComponent(tableToolbar);
+            final String tableUniqueIdentifier = table.getModelUniqueIdentifier();
+
             if (HtmlTableToolbar.EVENT_TOGGLE_COLUMN.equals(behaviorEvent) && table.getTableColumnVisibilityModel() != null) {
-                final TableColumnVisibility visibility = new JsonToModelConverter().convertTableColumnVisibility(tableUniqueIdentifier, params.get("params"));
+                final TableColumnVisibility visibility = new JsonToModelConverter().convertTableColumnVisibility(tableUniqueIdentifier, AjaxRequestParameter.findRequestParameter(context));
                 table.getTableColumnVisibilityModel().update(visibility);
             } else if (behaviorEvent.equals(HtmlTableToolbar.EVENT_REFRESH_TABLE)) {
                 if (tableToolbar.getTableToolbarRefreshListener() != null) {
                     tableToolbar.getTableToolbarRefreshListener().onPreRefresh();
                 }
             } else if (HtmlTableToolbar.EVENT_ORDER_COLUMN.equals(behaviorEvent) && table.getTableOrderingModel() != null) {
-                final TableColumnOrdering ordering = new JsonToModelConverter().convertTableColumnOrdering(tableUniqueIdentifier, params.get("params"));
+                final TableColumnOrdering ordering = new JsonToModelConverter().convertTableColumnOrdering(tableUniqueIdentifier, AjaxRequestParameter.findRequestParameter(context));
                 table.getTableOrderingModel().update(ordering);
             }
         }

--- a/components/src/main/java/org/butterfaces/component/renderkit/html_basic/text/TextRenderer.java
+++ b/components/src/main/java/org/butterfaces/component/renderkit/html_basic/text/TextRenderer.java
@@ -3,8 +3,7 @@ package org.butterfaces.component.renderkit.html_basic.text;
 import org.butterfaces.component.html.text.HtmlText;
 import org.butterfaces.component.html.text.part.HtmlAutoComplete;
 import org.butterfaces.component.partrenderer.RenderUtils;
-import org.butterfaces.util.StringUtils;
-import org.butterfaces.component.partrenderer.RenderUtils;
+import org.butterfaces.resolver.AjaxRequestParameter;
 import org.butterfaces.util.StringUtils;
 
 import javax.faces.component.UIComponent;
@@ -39,7 +38,7 @@ public class TextRenderer extends AbstractHtmlTagRenderer<HtmlText> {
             final ExternalContext external = context.getExternalContext();
             final Map<String, String> params = external.getRequestParameterMap();
             final String behaviorEvent = params.get("javax.faces.behavior.event");
-            final String searchValue = params.get("params");
+            final String searchValue = AjaxRequestParameter.findRequestParameter(context);
 
             if ("autocomplete".equals(behaviorEvent) && StringUtils.isNotEmpty(searchValue)) {
                 autoCompleteChild.getCachedAutoCompleteValues().clear();

--- a/components/src/main/java/org/butterfaces/component/renderkit/html_basic/text/TreeRenderer.java
+++ b/components/src/main/java/org/butterfaces/component/renderkit/html_basic/text/TreeRenderer.java
@@ -199,7 +199,7 @@ public class TreeRenderer extends HtmlBasicRenderer {
         final Map<String, String> params = external.getRequestParameterMap();
         final String behaviorEvent = params.get("javax.faces.behavior.event");
 
-        if (behaviorEvent != null && "click".equals(behaviorEvent)) {
+        if ("click".equals(behaviorEvent)) {
             try {
                 final Integer nodeNumber = Integer.valueOf(AjaxRequestParameter.findRequestParameter(context));
                 final Node node = nodesMap.get(nodeNumber);
@@ -211,7 +211,7 @@ public class TreeRenderer extends HtmlBasicRenderer {
             } catch (NumberFormatException e) {
                 // here is nothing to do
             }
-        } else if (behaviorEvent != null && "toggle".equals(behaviorEvent)) {
+        } else if ("toggle".equals(behaviorEvent)) {
             try {
                 final Integer nodeNumber = Integer.valueOf(AjaxRequestParameter.findRequestParameter(context));
                 final Node cachedNode = nodesMap.get(nodeNumber);

--- a/components/src/main/java/org/butterfaces/component/renderkit/html_basic/text/TreeRenderer.java
+++ b/components/src/main/java/org/butterfaces/component/renderkit/html_basic/text/TreeRenderer.java
@@ -11,6 +11,7 @@ import org.butterfaces.event.TreeNodeExpansionListener;
 import org.butterfaces.event.TreeNodeSelectionEvent;
 import org.butterfaces.event.TreeNodeSelectionListener;
 import org.butterfaces.model.tree.Node;
+import org.butterfaces.resolver.AjaxRequestParameter;
 import org.butterfaces.resolver.ClientBehaviorResolver;
 import org.butterfaces.resolver.MustacheResolver;
 import org.butterfaces.resolver.WebXmlParameters;
@@ -200,7 +201,7 @@ public class TreeRenderer extends HtmlBasicRenderer {
 
         if (behaviorEvent != null && "click".equals(behaviorEvent)) {
             try {
-                final Integer nodeNumber = Integer.valueOf(params.get("params"));
+                final Integer nodeNumber = Integer.valueOf(AjaxRequestParameter.findRequestParameter(context));
                 final Node node = nodesMap.get(nodeNumber);
                 if (nodeSelectionListener != null) {
                     final Integer selectedNodeNumber = getSelectedNodeNumber(tree, nodesMap);
@@ -212,7 +213,7 @@ public class TreeRenderer extends HtmlBasicRenderer {
             }
         } else if (behaviorEvent != null && "toggle".equals(behaviorEvent)) {
             try {
-                final Integer nodeNumber = Integer.valueOf(params.get("params"));
+                final Integer nodeNumber = Integer.valueOf(AjaxRequestParameter.findRequestParameter(context));
                 final Node cachedNode = nodesMap.get(nodeNumber);
                 if (cachedNode != null) {
                     if (cachedNode.isCollapsed()) {

--- a/components/src/main/java/org/butterfaces/resolver/AjaxRequestParameter.java
+++ b/components/src/main/java/org/butterfaces/resolver/AjaxRequestParameter.java
@@ -1,0 +1,19 @@
+package org.butterfaces.resolver;
+
+import org.butterfaces.util.StringUtils;
+
+import javax.faces.context.ExternalContext;
+import javax.faces.context.FacesContext;
+import java.util.Map;
+
+public class AjaxRequestParameter {
+
+    public static String findRequestParameter(final FacesContext context) {
+        final ExternalContext externalContext = context.getExternalContext();
+        final Map<String, String> requestParameterMap = externalContext.getRequestParameterMap();
+        final String params = requestParameterMap.get("params");
+
+        return StringUtils.isNotEmpty(params) ? params : requestParameterMap.get("butterfaces.params");
+    }
+
+}

--- a/components/src/main/resources/META-INF/faces-config.xml
+++ b/components/src/main/resources/META-INF/faces-config.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <faces-config xmlns="http://xmlns.jcp.org/xml/ns/javaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd"
-              version="2.2">
+              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_3.xsd"
+              version="2.3">
 
     <!-- @FacesRenderer is used instead -->
     <!-- render-kit>

--- a/components/src/main/resources/META-INF/resources/butterfaces-js/butterfaces-autocomplete.jquery.js
+++ b/components/src/main/resources/META-INF/resources/butterfaces-js/butterfaces-autocomplete.jquery.js
@@ -160,11 +160,13 @@
             // console.log("starting request");
 
             var id = self.$input.parent().parent().attr('id');
+            var params = self.$input.val();
 
             jsf.ajax.request(id, "autocomplete", {
                 "javax.faces.behavior.event": "autocomplete",
                 render: self.autocompleteId,
-                params: self.$input.val(),
+                params: params,
+                "butterfaces.params": params,
                 onevent: function (data) {
                     if (data.status === "success") {
                         // console.log("request finished");

--- a/components/src/test/java/org/butterfaces/component/html/ajax/JsfAjaxRequestTest.java
+++ b/components/src/test/java/org/butterfaces/component/html/ajax/JsfAjaxRequestTest.java
@@ -115,6 +115,7 @@ class JsfAjaxRequestTest {
                 + ", onevent: function(data){myEventHandler(data);}"
                 + ", onerror: function(data){myErrorHandler(data);}"
                 + ", params: myParams"
+                + ", 'butterfaces.params': myParams"
                 + "});");
 
         request.setBehaviorEvent("myBehaviorEvent");
@@ -123,6 +124,7 @@ class JsfAjaxRequestTest {
                 + ", onevent: function(data){myEventHandler(data);}"
                 + ", onerror: function(data){myErrorHandler(data);}"
                 + ", params: myParams"
+                + ", 'butterfaces.params': myParams"
                 + ", 'javax.faces.behavior.event': 'myBehaviorEvent'"
                 + "});");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -71,11 +71,7 @@
 
         <!-- maven plugin dependency version -->
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <maven-embedded-glassfish-plugin.version>3.1</maven-embedded-glassfish-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-
-        <!-- wildfly swarm -->
-        <io.thorntail>2.5.0.Final</io.thorntail>
 
         <!-- testing -->
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
@@ -141,11 +137,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.thorntail</groupId>
-                <artifactId>bom</artifactId>
-                <version>${io.thorntail}</version>
-            </dependency>
-            <dependency>
                 <groupId>javax</groupId>
                 <artifactId>javaee-api</artifactId>
                 <version>${javax.javaee-api.version}</version>
@@ -161,6 +152,7 @@
                 <groupId>javax.faces</groupId>
                 <artifactId>javax.faces-api</artifactId>
                 <version>${javax.faces-api.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.butterfaces</groupId>

--- a/showcase/pom.xml
+++ b/showcase/pom.xml
@@ -14,6 +14,9 @@
     <name>ButterFaces showcase</name>
 
     <properties>
+        <!-- wildfly swarm -->
+        <io.thorntail>2.5.0.Final</io.thorntail>
+
         <docker-maven-plugin.version>1.2.1</docker-maven-plugin.version>
     </properties>
 
@@ -41,14 +44,6 @@
     <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>
-            <plugin>
-                <groupId>io.thorntail</groupId>
-                <artifactId>thorntail-maven-plugin</artifactId>
-                <version>${io.thorntail}</version>
-                <configuration>
-                    <propertiesFile>${project.basedir}/src/main/resources/wildfly.properties</propertiesFile>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.lesscss</groupId>
                 <artifactId>lesscss-maven-plugin</artifactId>
@@ -124,37 +119,6 @@
 
     <profiles>
         <profile>
-            <id>showcase-with-thorntail</id>
-            <dependencies>
-                <dependency>
-                    <groupId>io.thorntail</groupId>
-                    <artifactId>jsf</artifactId>
-                    <version>${io.thorntail}</version>
-                </dependency>
-                <dependency>
-                    <groupId>io.thorntail</groupId>
-                    <artifactId>cdi</artifactId>
-                    <version>${io.thorntail}</version>
-                </dependency>
-            </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.thorntail</groupId>
-                        <artifactId>thorntail-maven-plugin</artifactId>
-                        <version>${io.thorntail}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>package</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>showcase-with-thorntail-in-docker</id>
             <dependencies>
                 <dependency>
@@ -174,6 +138,9 @@
                         <groupId>io.thorntail</groupId>
                         <artifactId>thorntail-maven-plugin</artifactId>
                         <version>${io.thorntail}</version>
+                        <configuration>
+                            <propertiesFile>${project.basedir}/src/main/resources/wildfly.properties</propertiesFile>
+                        </configuration>
                         <executions>
                             <execution>
                                 <goals>

--- a/showcase/src/main/webapp/WEB-INF/faces-config.xml
+++ b/showcase/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<faces-config version="2.0" 
-			  xmlns="http://java.sun.com/xml/ns/javaee"
-			  xmlns:xi="http://www.w3.org/2001/XInclude" 
-			  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-			  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd">
+<faces-config xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_3.xsd"
+              version="2.3">
 
 	<application>
         <resource-handler>org.butterfaces.handler.ButterFacesResourceHandler</resource-handler>

--- a/showcase/src/main/webapp/WEB-INF/web.xml
+++ b/showcase/src/main/webapp/WEB-INF/web.xml
@@ -17,7 +17,7 @@
 
     <context-param>
         <param-name>javax.faces.PROJECT_STAGE</param-name>
-        <param-value>Development</param-value>
+        <param-value>Production</param-value>
         <!--<param-value>Production</param-value>-->
         <!--<param-value>Development</param-value>-->
     </context-param>

--- a/showcase/src/main/webapp/WEB-INF/web.xml
+++ b/showcase/src/main/webapp/WEB-INF/web.xml
@@ -17,7 +17,7 @@
 
     <context-param>
         <param-name>javax.faces.PROJECT_STAGE</param-name>
-        <param-value>Production</param-value>
+        <param-value>Development</param-value>
         <!--<param-value>Production</param-value>-->
         <!--<param-value>Development</param-value>-->
     </context-param>


### PR DESCRIPTION
@szerhusenBC please review this PR and give me feedback.

It seems that attribute 'params' is not supported by thorntail or wildfly 17 when using JSF 2.3. I cannot find any specification updates.

I've replaced 'params' by 'butterfaces.params' when using jsf.ajax.request but this breaks JSF specification. 